### PR TITLE
Support Embedded Applications (such as Electron)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
-# `bindings-loader`
+# bindings-loader [![npm version](https://badge.fury.io/js/bindings-loader.svg)](https://badge.fury.io/js/bindings-loader)
 
-A webpack loader for node addon modules that handles the recommended
-`require("bindings")("myaddon.node")` pattern.
+A webpack loader for node addon modules that handles the recommended `require("bindings")("myaddon.node")` pattern. This borrows heavily from `awesome-node-loader` (huge credit to its contributors!) with how it handles node addons in your code, but extends the usability to include all dependencies in node_modules.
 
-Very early, use at your own risk, but feedback welcome!
+## Installation
 
-## Usage
+Add the package to the `package.json` file:
 
-No options at the moment, always emits all `.node` files directly in the output
-directory.
+```bash
+$ npm install bindings-loader --save-dev
+$ yarn add --dev bindings-loader
+```
+
+## Usage + Options
+
+Always emits all `.node` files directly in the bundle root.
+
+### `useDirname`
+
+This option chooses in between `__dirname` and `path.dirname(process.execPath)`. (Default is `false` -> `__dirname`)
+
+## Sample Config
 
 ```js
 // webpack.config.js
@@ -24,30 +35,29 @@ module.exports = {
   ],
   module: {
     rules: [
-      // ...
-      // Rewrites and emits
-      {
-        test: /\.js$/,
-        loader: "bindings-loader",
-      },
+    {
+      test: /\.js$/,
+      loader: "bindings-loader",
+      options: {
+        useDirname: !isElectronApp,
+      }
+    },
     ],
   },
 };
 ```
 
-In theory this should also work well chained with 'node-loader' to bundle the
-binary into the JS bundle, but I haven't tried.
-
 ## Behavior
 
-Recognizes `require('bindings')('foo.node')`, uses (roughly)
-`require('bindings')({ path: true, bindings: 'foo.node' })` to get the built
-addon module, re-writes the require to `require('./foo.node')`, and emits the
-referenced file at that relative path.
+Recognizes `require('bindings')('foo.node')`, uses (roughly) `require('bindings')({ path: true, bindings: 'foo.node' })` to get the built addon module, re-writes the require to `require("path").join(__dirname, 'foo.node')` when `useDirname = true`, and emits the referenced file at that bundle destination.
 
-Should also handle `require('bindings')({ bindings: 'foo.node', ... })`,
-including with `path: true` to just get the path, but that has even less testing
-than the rest of this module.
+## Future Options Improvements
+PRs welcome!
 
-No options are supported yet, in theory this should support most everything
-`file-loader` does to control the `.node` file output.
+### `name`
+
+This option would allow changing the file name in the output directory and allow usage of all placeholders defined in the [loader-utils](https://github.com/webpack/loader-utils/tree/v1.1.0#interpolatename) package.
+
+### `rewritePath`
+
+This option would need to remain `undefined` if you are building a package with embedded files, such as with Electron.

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ module.exports = function(source, map, meta) {
       if (typeof arg === "string") {
         arg = { bindings: arg };
       }
-      const forPath = !!arg.path;
       arg.path = true;
       arg.module_root = arg.module_root
         ? await resolve(arg.module_root)
@@ -54,10 +53,8 @@ module.exports = function(source, map, meta) {
 
       replaceSource.replace(
         match.index,
-        pattern.lastIndex,
-        forPath
-          ? JSON.stringify(addonRequest)
-          : `require(${JSON.stringify(addonRequest)})`,
+        pattern.lastIndex - 1,
+        `(typeof __webpack_require__ === "function" ? __non_webpack_require__ : require)(require(\"path\").join(${!!options.useDirname ? "__dirname" : "require(\"path\").dirname(process.execPath)"}, "${addonRequest}"))`
       );
 
       match = pattern.exec(source);


### PR DESCRIPTION
- Adds compatibility for electron applications. Borrows heavily from `awesome-node-loader` to also allow option `useDirname`
- Switches relative path to use `__dirname` for non-embedded applications and allow usage of `process.execPath` for embedded applications.
- Fixes bug with replace's `lastIndex` due to offset when chaining binding calls. [Example from `leveldown`:](https://github.com/Level/leveldown/blob/v4.0.2/leveldown.js#L3) `const binding = require('bindings')('leveldown').leveldown` would be missing the `.` prior to `leveldown`