### PR TITLE
bug fix with replace's end boundary

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = function(source, map, meta) {
 
       replaceSource.replace(
         match.index,
-        pattern.lastIndex,
+        pattern.lastIndex - 1,
         forPath
           ? JSON.stringify(addonRequest)
           : `require(${JSON.stringify(addonRequest)})`,


### PR DESCRIPTION
Many thanks for your great code which have solved my webpack problem. But if I didn't make a mistake, the replace function's second argument isn't accurate, so the replace would "eat" a letter below.